### PR TITLE
Added private boards. 

### DIFF
--- a/src/main/scala/com/balopat/codingboard/CodingBoard.scala
+++ b/src/main/scala/com/balopat/codingboard/CodingBoard.scala
@@ -1,7 +1,12 @@
 package com.balopat.codingboard
 
 
-case class CodingBoard (board: String, lengthOfSessionInMillis: Long, creationTimeInMillis: Long) {
+case class CodingBoard (
+    board: String, 
+    lengthOfSessionInMillis: Long, 
+    creationTimeInMillis: Long,
+    isPrivate: Boolean = false 
+) { 
 
   var codeSnippets = List[CodeSnippet]()
   

--- a/src/main/scala/com/balopat/codingboard/CodingBoardServlet.scala
+++ b/src/main/scala/com/balopat/codingboard/CodingBoardServlet.scala
@@ -8,7 +8,8 @@ class CodingBoardServlet(boards: CodingBoards = CodingBoards.instance) extends C
     }
 
     post("/submitboard") {
-       createAndJoinBoard(params("board"), params("lengthOfSessionInMinutes")) 
+       val isPrivate = params.get("private").isDefined
+       createAndJoinBoard(params("board"), params("lengthOfSessionInMinutes"), isPrivate ) 
     }
 
     get("/boards/:board") {

--- a/src/main/scala/com/balopat/codingboard/CodingBoardViewHelper.scala
+++ b/src/main/scala/com/balopat/codingboard/CodingBoardViewHelper.scala
@@ -51,13 +51,13 @@ class CodingBoardViewHelper(boards: CodingBoards = CodingBoards.instance) extend
        )
     }
 
-    def createAndJoinBoard(board: String, lengthOfSession: String) = { 
+    def createAndJoinBoard(board: String, lengthOfSession: String, isPrivate: Boolean) = { 
          val validationErrors = boards.validate(board, lengthOfSession)
          if (!validationErrors.isEmpty) {
              contentType="text/html"
              jade("createboard", (validationErrors :+ ("board"->board) :+ ("lengthOfSession" -> lengthOfSession)).toArray :_* )
          } else {
-           joinCodingBoard(boards.create(board, lengthOfSession.toInt * 60000, System.currentTimeMillis).url)
+           joinCodingBoard(boards.create(board, lengthOfSession.toInt * 60000, System.currentTimeMillis, isPrivate).url)
          }   
     }  
   

--- a/src/main/scala/com/balopat/codingboard/CodingBoards.scala
+++ b/src/main/scala/com/balopat/codingboard/CodingBoards.scala
@@ -14,8 +14,8 @@ class CodingBoards {
   val boards = Map[String, CodingBoard]()
   private var formTokens = scala.collection.mutable.Seq[String]()
 
-  def create(boardName:String, lengthOfSessionInMillis: Long, creationTimeInMillis: Long) = {
-    val board = new CodingBoard(boardName, lengthOfSessionInMillis, creationTimeInMillis)
+  def create(boardName:String, lengthOfSessionInMillis: Long, creationTimeInMillis: Long, isPrivate: Boolean) = {
+    val board = new CodingBoard(boardName, lengthOfSessionInMillis, creationTimeInMillis, isPrivate)
     boards += (board.url -> board)
     actor {
       receiveWithin(lengthOfSessionInMillis) {
@@ -28,7 +28,13 @@ class CodingBoards {
 
   def get(boardURL: String) =  boards(boardURL)
   def exists(boardURL: String) = boards.contains(boardURL)
-  def list = boards.values
+  
+  /**
+   * List of all non-private boards. 
+   * This means private boards can only accessed if you know their id. Could be done in controller.
+   */
+  def list = boards.values filter ( !_.isPrivate ) 
+  
   def remove(boardURL: String) = boards.remove(boardURL)
 
   val boardNameValidations = List[(String, String => Boolean)](

--- a/src/main/webapp/WEB-INF/views/board.jade
+++ b/src/main/webapp/WEB-INF/views/board.jade
@@ -29,6 +29,9 @@
 <script type="text/javascript" src="/js/shBrushXml.js"></script>
 <script type="text/javascript" src="/js/shBrushClojure.js"></script>
 
+<script src="http://d1n0x3qji82z53.cloudfront.net/src-min-noconflict/ace.js" type="text/javascript" charset="utf-8"></script>
+
+
 
 link(href="/css/shCore.css" rel="stylesheet" type="text/css")/
 link(href="/css/shThemeMidnight.css" rel="stylesheet" type="text/css")/
@@ -45,14 +48,21 @@ div(class="container")
             div
                 b= codeSnippet.description
             div
-                pre(class="brush: #{codeSnippet.language}")= "\n" + codeSnippet.code
+                #editor(class='#{codeSnippet.id}')
+            :javascript
+                var editor = ace.edit('#editor #{codeSnippet.id}');
+                var languageMode = "ace/mode/#{codeSnippet.language}"
+                editor.setValue("#{codeSnippet.code}");
+                editor.getSession().setMode(languageMode);
             div
             i= codeSnippet.formattedTime
 
-<script type="text/javascript">
-| SyntaxHighlighter.all();
-| var lastCodeSnippetId = '#{board.lastCodeSnippetId}';
-| var board = '#{board.board}';
-|</script>
+
+//    <script type="text/javascript">
+//    | SyntaxHighlighter.all();
+//    | var lastCodeSnippetId = '#{board.lastCodeSnippetId}';
+//    | var board = '#{board.board}';
+//    |</script>
 <script src="/js/jquery-1.7.2.js"></script>
 <script src="/js/application.js"></script>
+

--- a/src/main/webapp/WEB-INF/views/board.jade
+++ b/src/main/webapp/WEB-INF/views/board.jade
@@ -29,9 +29,6 @@
 <script type="text/javascript" src="/js/shBrushXml.js"></script>
 <script type="text/javascript" src="/js/shBrushClojure.js"></script>
 
-<script src="http://d1n0x3qji82z53.cloudfront.net/src-min-noconflict/ace.js" type="text/javascript" charset="utf-8"></script>
-
-
 
 link(href="/css/shCore.css" rel="stylesheet" type="text/css")/
 link(href="/css/shThemeMidnight.css" rel="stylesheet" type="text/css")/
@@ -48,22 +45,14 @@ div(class="container")
             div
                 b= codeSnippet.description
             div
-                #editor(class='#{codeSnippet.id}')
-            <script type="text/javascript">
-            |    var editor = ace.edit('#editor #{codeSnippet.id}');
-            |    var languageMode = "ace/mode/#{codeSnippet.language}"
-            |    editor.setValue("#{codeSnippet.code}");
-            |    editor.getSession().setMode(languageMode);
-            | </script>
+                pre(class="brush: #{codeSnippet.language}")= "\n" + codeSnippet.code
             div
             i= codeSnippet.formattedTime
 
-
-//    <script type="text/javascript">
-//    | SyntaxHighlighter.all();
-//    | var lastCodeSnippetId = '#{board.lastCodeSnippetId}';
-//    | var board = '#{board.board}';
-//    |</script>
+<script type="text/javascript">
+| SyntaxHighlighter.all();
+| var lastCodeSnippetId = '#{board.lastCodeSnippetId}';
+| var board = '#{board.board}';
+|</script>
 <script src="/js/jquery-1.7.2.js"></script>
 <script src="/js/application.js"></script>
-

--- a/src/main/webapp/WEB-INF/views/board.jade
+++ b/src/main/webapp/WEB-INF/views/board.jade
@@ -49,11 +49,12 @@ div(class="container")
                 b= codeSnippet.description
             div
                 #editor(class='#{codeSnippet.id}')
-            :javascript
-                var editor = ace.edit('#editor #{codeSnippet.id}');
-                var languageMode = "ace/mode/#{codeSnippet.language}"
-                editor.setValue("#{codeSnippet.code}");
-                editor.getSession().setMode(languageMode);
+            <script type="text/javascript">
+            |    var editor = ace.edit('#editor #{codeSnippet.id}');
+            |    var languageMode = "ace/mode/#{codeSnippet.language}"
+            |    editor.setValue("#{codeSnippet.code}");
+            |    editor.getSession().setMode(languageMode);
+            | </script>
             div
             i= codeSnippet.formattedTime
 

--- a/src/main/webapp/WEB-INF/views/codesnippet.jade
+++ b/src/main/webapp/WEB-INF/views/codesnippet.jade
@@ -12,7 +12,7 @@ div
                 h2 Share your code
             input(type="hidden" name="formtoken" value="#{formtoken}" id="formtoken")
             div
-                input(placeholder="Description`..." name="description" id="description")
+                input(placeholder="Description..." name="description" id="description")
             #editor-wrap
                 #editor
             input(type='hidden' name='code')

--- a/src/main/webapp/WEB-INF/views/createboard.jade
+++ b/src/main/webapp/WEB-INF/views/createboard.jade
@@ -14,6 +14,8 @@ form(method="POST" action="submitboard")
         div
             p(class="text-error")=boardNameError
         div
+            input(type="checkbox" name="private" id="private" value="")
+        div
             input(placeholder="Lifetime of your board in minutes" name="lengthOfSessionInMinutes" id="lengthOfSessionInMinutes" value="#{lengthOfSession}" size="50")
         div
             p(class="text-error")=lengthOfSessionError

--- a/src/main/webapp/WEB-INF/views/createboard.jade
+++ b/src/main/webapp/WEB-INF/views/createboard.jade
@@ -14,6 +14,7 @@ form(method="POST" action="submitboard")
         div
             p(class="text-error")=boardNameError
         div
+            label(style="display:inline") Private board?:
             input(type="checkbox" name="private" id="private" value="")
         div
             input(placeholder="Lifetime of your board in minutes" name="lengthOfSessionInMinutes" id="lengthOfSessionInMinutes" value="#{lengthOfSession}" size="50")

--- a/src/test/scala/com/balopat/codingboard/CodingBoardSpec.scala
+++ b/src/test/scala/com/balopat/codingboard/CodingBoardSpec.scala
@@ -11,7 +11,7 @@ class CodingBoardSpec extends Specification {
 
        "return empty String for "+ 
        "the lastCodeSnippet id if there are no codesnippets" in {
-          aBoard.lastCodeSnippetId should_==("")
+          aBoard.lastCodeSnippetId should_==("N/A")
        }
 
        "return the last codeSnippet id" in {
@@ -44,7 +44,8 @@ class CodingBoardSpec extends Specification {
        def aBoard() = {
          val lifeTimeInMinutes =  500000
          val creationTimeInMillis = 1000
-         new CodingBoard("board", lifeTimeInMinutes, creationTimeInMillis)
+         val isPrivate = false
+         new CodingBoard("board", lifeTimeInMinutes, creationTimeInMillis, isPrivate)
        }
 
 

--- a/src/test/scala/com/balopat/codingboard/CodingBoardsSpec.scala
+++ b/src/test/scala/com/balopat/codingboard/CodingBoardsSpec.scala
@@ -7,7 +7,8 @@ class CodingBoardsSpec extends Specification {
   val fixture = new {
      val boards = new CodingBoards()
      val lengthOfSessionInMillis = 10000   
-     val creationTimeInMillis: Long = 1000
+     val creationTimeInMillis = 1000l
+     val isPrivate = false
   }
 
 
@@ -39,6 +40,22 @@ class CodingBoardsSpec extends Specification {
       
       fixture.boards.list.map(_.board) must contain ("t1", "t2", "t3")
     }
+    
+    "Private boards should not be included in 'list'" in {
+      aTestCodingBoard("p1")
+      aTestCodingBoard("p2",true)
+      
+      val boards = fixture.boards.list.map(_.board)
+      
+      boards must contain ("p1")
+      boards must not contain ("p2")
+    }
+  
+    "Private boards should available when ID is known" in {
+      aTestCodingBoard("t2",true)
+      
+      fixture.boards.get("t2") must not(throwA[NoSuchElementException])
+    }
   
     "not allow empty boardname" in {
       fixture.boards.validate("", "1") should beEqualTo(Seq("boardNameError"->"Board name cannot be empty"))    
@@ -64,7 +81,7 @@ class CodingBoardsSpec extends Specification {
     }
 
     "remove the board after expiry" in {
-      fixture.boards.create("expiring board", 100, 1000)
+      fixture.boards.create("expiring board", 100, 1000, false)
       Thread.sleep(101)
       fixture.boards.exists("expiring board") should beFalse
     }
@@ -73,8 +90,8 @@ class CodingBoardsSpec extends Specification {
       CodingBoards.instance should not beNull
     }
 
-    def aTestCodingBoard(name: String = "testingCodingBoard")  = { 
-        fixture.boards.create(name, fixture.lengthOfSessionInMillis, fixture.creationTimeInMillis)
+    def aTestCodingBoard(name: String = "testingCodingBoard", isPrivate: Boolean = fixture.isPrivate)  = { 
+        fixture.boards.create(name, fixture.lengthOfSessionInMillis, fixture.creationTimeInMillis, isPrivate)
     }
 
     def cleanUpBoards() = {


### PR DESCRIPTION
Fixes issue 6. (Issue 4 & 7 should closed too from previous pull requests.)

createboard view could look a little nicer, but it's fine.

One test is broken, doesn't seem related to my changes though.

[info] + not return a board when removed
[error] x returns the name of the boards
[error]    List(t3, testCodingBoard1, p1, testCodingBoard2, t1) doesn't contain 't2' (CodingBoardsSpec.scala:43)
