### PR TITLE
Switch between themes.

### DIFF
--- a/src/main/webapp/WEB-INF/views/board.jade
+++ b/src/main/webapp/WEB-INF/views/board.jade
@@ -32,7 +32,14 @@
 <script type="text/javascript" src="/js/codingBoard.js"></script>
 
 link(href="/css/shCore.css" rel="stylesheet" type="text/css")/
-link(href="/css/shThemeMidnight.css" rel="stylesheet" type="text/css")/
+link(href="/css/shThemeDefault.css" title="theme-default" disabled="disabled" rel="stylesheet" type="text/css")/
+link(href="/css/shThemeDjango.css" title="theme-django" disabled="disabled" rel="stylesheet" type="text/css")/
+link(href="/css/shThemeEclipse.css" title="theme-eclipse" disabled="disabled" rel="stylesheet" type="text/css")/
+link(href="/css/shThemeEmacs.css" title="theme-emacs" disabled="disabled" rel="stylesheet" type="text/css")/
+link(href="/css/shThemeFadeToGrey.css" title="theme-fadetogrey" disabled="disabled" rel="stylesheet" type="text/css")/
+link(href="/css/shThemeMDUltra.css" title="theme-mdultra" disabled="disabled" rel="stylesheet" type="text/css")/
+link(href="/css/shThemeMidnight.css" title="theme-midnight" rel="stylesheet" type="text/css")/
+link(href="/css/shThemeRDark.css" title="theme-rdark" disabled="disabled" rel="stylesheet" type="text/css")/
 
 div(class="container")
     div(class="row span8")
@@ -43,14 +50,18 @@ div(class="container")
                 code(style='float:right')
                     :javascript
                         document.write(window.location)
-        span(id="time-left") #{board.timeLeftInSeconds(System.currentTimeMillis)} seconds left
+        p(id="time-left") #{board.timeLeftInSeconds(System.currentTimeMillis)} seconds left
         <script type="text/javascript">
         |    var timeLeftInSeconds = parseInt('#{board.timeLeftInSeconds(System.currentTimeMillis)}'.replace(',',''));
         |    scheduleTimerUpdate('time-left', timeLeftInSeconds);
         | </script>
-        br
+
+    div(class="row span8")
+        p(id="themes")
+            span Theme:
+
     div(class="row span8 offset3")
-        button(class="btn btn-info btn-large" onclick="window.location='/boards/#{board.url}/codesnippet'") share a codesnippet 
+        button(class="btn btn-info btn-large" onclick="window.location='/boards/#{board.url}/codesnippet'") share a codesnippet
 
     div(class="row span11 " id="codeSnippets")
         - for (codeSnippet <- board.codeSnippets.reverse)

--- a/src/main/webapp/css/shThemeDefault.css
+++ b/src/main/webapp/css/shThemeDefault.css
@@ -1,0 +1,117 @@
+/**
+ * SyntaxHighlighter
+ * http://alexgorbatchev.com/SyntaxHighlighter
+ *
+ * SyntaxHighlighter is donationware. If you are using it, please donate.
+ * http://alexgorbatchev.com/SyntaxHighlighter/donate.html
+ *
+ * @version
+ * 3.0.83 (July 02 2010)
+ * 
+ * @copyright
+ * Copyright (C) 2004-2010 Alex Gorbatchev.
+ *
+ * @license
+ * Dual licensed under the MIT and GPL licenses.
+ */
+.syntaxhighlighter {
+  background-color: white !important;
+}
+.syntaxhighlighter .line.alt1 {
+  background-color: white !important;
+}
+.syntaxhighlighter .line.alt2 {
+  background-color: white !important;
+}
+.syntaxhighlighter .line.highlighted.alt1, .syntaxhighlighter .line.highlighted.alt2 {
+  background-color: #e0e0e0 !important;
+}
+.syntaxhighlighter .line.highlighted.number {
+  color: black !important;
+}
+.syntaxhighlighter table caption {
+  color: black !important;
+}
+.syntaxhighlighter .gutter {
+  color: #afafaf !important;
+}
+.syntaxhighlighter .gutter .line {
+  border-right: 3px solid #6ce26c !important;
+}
+.syntaxhighlighter .gutter .line.highlighted {
+  background-color: #6ce26c !important;
+  color: white !important;
+}
+.syntaxhighlighter.printing .line .content {
+  border: none !important;
+}
+.syntaxhighlighter.collapsed {
+  overflow: visible !important;
+}
+.syntaxhighlighter.collapsed .toolbar {
+  color: blue !important;
+  background: white !important;
+  border: 1px solid #6ce26c !important;
+}
+.syntaxhighlighter.collapsed .toolbar a {
+  color: blue !important;
+}
+.syntaxhighlighter.collapsed .toolbar a:hover {
+  color: red !important;
+}
+.syntaxhighlighter .toolbar {
+  color: white !important;
+  background: #6ce26c !important;
+  border: none !important;
+}
+.syntaxhighlighter .toolbar a {
+  color: white !important;
+}
+.syntaxhighlighter .toolbar a:hover {
+  color: black !important;
+}
+.syntaxhighlighter .plain, .syntaxhighlighter .plain a {
+  color: black !important;
+}
+.syntaxhighlighter .comments, .syntaxhighlighter .comments a {
+  color: #008200 !important;
+}
+.syntaxhighlighter .string, .syntaxhighlighter .string a {
+  color: blue !important;
+}
+.syntaxhighlighter .keyword {
+  color: #006699 !important;
+}
+.syntaxhighlighter .preprocessor {
+  color: gray !important;
+}
+.syntaxhighlighter .variable {
+  color: #aa7700 !important;
+}
+.syntaxhighlighter .value {
+  color: #009900 !important;
+}
+.syntaxhighlighter .functions {
+  color: #ff1493 !important;
+}
+.syntaxhighlighter .constants {
+  color: #0066cc !important;
+}
+.syntaxhighlighter .script {
+  font-weight: bold !important;
+  color: #006699 !important;
+  background-color: none !important;
+}
+.syntaxhighlighter .color1, .syntaxhighlighter .color1 a {
+  color: gray !important;
+}
+.syntaxhighlighter .color2, .syntaxhighlighter .color2 a {
+  color: #ff1493 !important;
+}
+.syntaxhighlighter .color3, .syntaxhighlighter .color3 a {
+  color: red !important;
+}
+
+.syntaxhighlighter .keyword {
+  font-weight: bold !important;
+}

--- a/src/main/webapp/css/shThemeDjango.css
+++ b/src/main/webapp/css/shThemeDjango.css
@@ -1,0 +1,120 @@
+/**
+ * SyntaxHighlighter
+ * http://alexgorbatchev.com/SyntaxHighlighter
+ *
+ * SyntaxHighlighter is donationware. If you are using it, please donate.
+ * http://alexgorbatchev.com/SyntaxHighlighter/donate.html
+ *
+ * @version
+ * 3.0.83 (July 02 2010)
+ * 
+ * @copyright
+ * Copyright (C) 2004-2010 Alex Gorbatchev.
+ *
+ * @license
+ * Dual licensed under the MIT and GPL licenses.
+ */
+.syntaxhighlighter {
+  background-color: #0a2b1d !important;
+}
+.syntaxhighlighter .line.alt1 {
+  background-color: #0a2b1d !important;
+}
+.syntaxhighlighter .line.alt2 {
+  background-color: #0a2b1d !important;
+}
+.syntaxhighlighter .line.highlighted.alt1, .syntaxhighlighter .line.highlighted.alt2 {
+  background-color: #233729 !important;
+}
+.syntaxhighlighter .line.highlighted.number {
+  color: white !important;
+}
+.syntaxhighlighter table caption {
+  color: #f8f8f8 !important;
+}
+.syntaxhighlighter .gutter {
+  color: #497958 !important;
+}
+.syntaxhighlighter .gutter .line {
+  border-right: 3px solid #41a83e !important;
+}
+.syntaxhighlighter .gutter .line.highlighted {
+  background-color: #41a83e !important;
+  color: #0a2b1d !important;
+}
+.syntaxhighlighter.printing .line .content {
+  border: none !important;
+}
+.syntaxhighlighter.collapsed {
+  overflow: visible !important;
+}
+.syntaxhighlighter.collapsed .toolbar {
+  color: #96dd3b !important;
+  background: black !important;
+  border: 1px solid #41a83e !important;
+}
+.syntaxhighlighter.collapsed .toolbar a {
+  color: #96dd3b !important;
+}
+.syntaxhighlighter.collapsed .toolbar a:hover {
+  color: white !important;
+}
+.syntaxhighlighter .toolbar {
+  color: white !important;
+  background: #41a83e !important;
+  border: none !important;
+}
+.syntaxhighlighter .toolbar a {
+  color: white !important;
+}
+.syntaxhighlighter .toolbar a:hover {
+  color: #ffe862 !important;
+}
+.syntaxhighlighter .plain, .syntaxhighlighter .plain a {
+  color: #f8f8f8 !important;
+}
+.syntaxhighlighter .comments, .syntaxhighlighter .comments a {
+  color: #336442 !important;
+}
+.syntaxhighlighter .string, .syntaxhighlighter .string a {
+  color: #9df39f !important;
+}
+.syntaxhighlighter .keyword {
+  color: #96dd3b !important;
+}
+.syntaxhighlighter .preprocessor {
+  color: #91bb9e !important;
+}
+.syntaxhighlighter .variable {
+  color: #ffaa3e !important;
+}
+.syntaxhighlighter .value {
+  color: #f7e741 !important;
+}
+.syntaxhighlighter .functions {
+  color: #ffaa3e !important;
+}
+.syntaxhighlighter .constants {
+  color: #e0e8ff !important;
+}
+.syntaxhighlighter .script {
+  font-weight: bold !important;
+  color: #96dd3b !important;
+  background-color: none !important;
+}
+.syntaxhighlighter .color1, .syntaxhighlighter .color1 a {
+  color: #eb939a !important;
+}
+.syntaxhighlighter .color2, .syntaxhighlighter .color2 a {
+  color: #91bb9e !important;
+}
+.syntaxhighlighter .color3, .syntaxhighlighter .color3 a {
+  color: #edef7d !important;
+}
+
+.syntaxhighlighter .comments {
+  font-style: italic !important;
+}
+.syntaxhighlighter .keyword {
+  font-weight: bold !important;
+}

--- a/src/main/webapp/css/shThemeEclipse.css
+++ b/src/main/webapp/css/shThemeEclipse.css
@@ -1,0 +1,128 @@
+/**
+ * SyntaxHighlighter
+ * http://alexgorbatchev.com/SyntaxHighlighter
+ *
+ * SyntaxHighlighter is donationware. If you are using it, please donate.
+ * http://alexgorbatchev.com/SyntaxHighlighter/donate.html
+ *
+ * @version
+ * 3.0.83 (July 02 2010)
+ * 
+ * @copyright
+ * Copyright (C) 2004-2010 Alex Gorbatchev.
+ *
+ * @license
+ * Dual licensed under the MIT and GPL licenses.
+ */
+.syntaxhighlighter {
+  background-color: white !important;
+}
+.syntaxhighlighter .line.alt1 {
+  background-color: white !important;
+}
+.syntaxhighlighter .line.alt2 {
+  background-color: white !important;
+}
+.syntaxhighlighter .line.highlighted.alt1, .syntaxhighlighter .line.highlighted.alt2 {
+  background-color: #c3defe !important;
+}
+.syntaxhighlighter .line.highlighted.number {
+  color: white !important;
+}
+.syntaxhighlighter table caption {
+  color: black !important;
+}
+.syntaxhighlighter .gutter {
+  color: #787878 !important;
+}
+.syntaxhighlighter .gutter .line {
+  border-right: 3px solid #d4d0c8 !important;
+}
+.syntaxhighlighter .gutter .line.highlighted {
+  background-color: #d4d0c8 !important;
+  color: white !important;
+}
+.syntaxhighlighter.printing .line .content {
+  border: none !important;
+}
+.syntaxhighlighter.collapsed {
+  overflow: visible !important;
+}
+.syntaxhighlighter.collapsed .toolbar {
+  color: #3f5fbf !important;
+  background: white !important;
+  border: 1px solid #d4d0c8 !important;
+}
+.syntaxhighlighter.collapsed .toolbar a {
+  color: #3f5fbf !important;
+}
+.syntaxhighlighter.collapsed .toolbar a:hover {
+  color: #aa7700 !important;
+}
+.syntaxhighlighter .toolbar {
+  color: #a0a0a0 !important;
+  background: #d4d0c8 !important;
+  border: none !important;
+}
+.syntaxhighlighter .toolbar a {
+  color: #a0a0a0 !important;
+}
+.syntaxhighlighter .toolbar a:hover {
+  color: red !important;
+}
+.syntaxhighlighter .plain, .syntaxhighlighter .plain a {
+  color: black !important;
+}
+.syntaxhighlighter .comments, .syntaxhighlighter .comments a {
+  color: #3f5fbf !important;
+}
+.syntaxhighlighter .string, .syntaxhighlighter .string a {
+  color: #2a00ff !important;
+}
+.syntaxhighlighter .keyword {
+  color: #7f0055 !important;
+}
+.syntaxhighlighter .preprocessor {
+  color: #646464 !important;
+}
+.syntaxhighlighter .variable {
+  color: #aa7700 !important;
+}
+.syntaxhighlighter .value {
+  color: #009900 !important;
+}
+.syntaxhighlighter .functions {
+  color: #ff1493 !important;
+}
+.syntaxhighlighter .constants {
+  color: #0066cc !important;
+}
+.syntaxhighlighter .script {
+  font-weight: bold !important;
+  color: #7f0055 !important;
+  background-color: none !important;
+}
+.syntaxhighlighter .color1, .syntaxhighlighter .color1 a {
+  color: gray !important;
+}
+.syntaxhighlighter .color2, .syntaxhighlighter .color2 a {
+  color: #ff1493 !important;
+}
+.syntaxhighlighter .color3, .syntaxhighlighter .color3 a {
+  color: red !important;
+}
+
+.syntaxhighlighter .keyword {
+  font-weight: bold !important;
+}
+.syntaxhighlighter .xml .keyword {
+  color: #3f7f7f !important;
+  font-weight: normal !important;
+}
+.syntaxhighlighter .xml .color1, .syntaxhighlighter .xml .color1 a {
+  color: #7f007f !important;
+}
+.syntaxhighlighter .xml .string {
+  font-style: italic !important;
+  color: #2a00ff !important;
+}

--- a/src/main/webapp/css/shThemeEmacs.css
+++ b/src/main/webapp/css/shThemeEmacs.css
@@ -1,0 +1,113 @@
+/**
+ * SyntaxHighlighter
+ * http://alexgorbatchev.com/SyntaxHighlighter
+ *
+ * SyntaxHighlighter is donationware. If you are using it, please donate.
+ * http://alexgorbatchev.com/SyntaxHighlighter/donate.html
+ *
+ * @version
+ * 3.0.83 (July 02 2010)
+ * 
+ * @copyright
+ * Copyright (C) 2004-2010 Alex Gorbatchev.
+ *
+ * @license
+ * Dual licensed under the MIT and GPL licenses.
+ */
+.syntaxhighlighter {
+  background-color: black !important;
+}
+.syntaxhighlighter .line.alt1 {
+  background-color: black !important;
+}
+.syntaxhighlighter .line.alt2 {
+  background-color: black !important;
+}
+.syntaxhighlighter .line.highlighted.alt1, .syntaxhighlighter .line.highlighted.alt2 {
+  background-color: #2a3133 !important;
+}
+.syntaxhighlighter .line.highlighted.number {
+  color: white !important;
+}
+.syntaxhighlighter table caption {
+  color: #d3d3d3 !important;
+}
+.syntaxhighlighter .gutter {
+  color: #d3d3d3 !important;
+}
+.syntaxhighlighter .gutter .line {
+  border-right: 3px solid #990000 !important;
+}
+.syntaxhighlighter .gutter .line.highlighted {
+  background-color: #990000 !important;
+  color: black !important;
+}
+.syntaxhighlighter.printing .line .content {
+  border: none !important;
+}
+.syntaxhighlighter.collapsed {
+  overflow: visible !important;
+}
+.syntaxhighlighter.collapsed .toolbar {
+  color: #ebdb8d !important;
+  background: black !important;
+  border: 1px solid #990000 !important;
+}
+.syntaxhighlighter.collapsed .toolbar a {
+  color: #ebdb8d !important;
+}
+.syntaxhighlighter.collapsed .toolbar a:hover {
+  color: #ff7d27 !important;
+}
+.syntaxhighlighter .toolbar {
+  color: white !important;
+  background: #990000 !important;
+  border: none !important;
+}
+.syntaxhighlighter .toolbar a {
+  color: white !important;
+}
+.syntaxhighlighter .toolbar a:hover {
+  color: #9ccff4 !important;
+}
+.syntaxhighlighter .plain, .syntaxhighlighter .plain a {
+  color: #d3d3d3 !important;
+}
+.syntaxhighlighter .comments, .syntaxhighlighter .comments a {
+  color: #ff7d27 !important;
+}
+.syntaxhighlighter .string, .syntaxhighlighter .string a {
+  color: #ff9e7b !important;
+}
+.syntaxhighlighter .keyword {
+  color: aqua !important;
+}
+.syntaxhighlighter .preprocessor {
+  color: #aec4de !important;
+}
+.syntaxhighlighter .variable {
+  color: #ffaa3e !important;
+}
+.syntaxhighlighter .value {
+  color: #009900 !important;
+}
+.syntaxhighlighter .functions {
+  color: #81cef9 !important;
+}
+.syntaxhighlighter .constants {
+  color: #ff9e7b !important;
+}
+.syntaxhighlighter .script {
+  font-weight: bold !important;
+  color: aqua !important;
+  background-color: none !important;
+}
+.syntaxhighlighter .color1, .syntaxhighlighter .color1 a {
+  color: #ebdb8d !important;
+}
+.syntaxhighlighter .color2, .syntaxhighlighter .color2 a {
+  color: #ff7d27 !important;
+}
+.syntaxhighlighter .color3, .syntaxhighlighter .color3 a {
+  color: #aec4de !important;
+}

--- a/src/main/webapp/css/shThemeFadeToGrey.css
+++ b/src/main/webapp/css/shThemeFadeToGrey.css
@@ -1,0 +1,117 @@
+/**
+ * SyntaxHighlighter
+ * http://alexgorbatchev.com/SyntaxHighlighter
+ *
+ * SyntaxHighlighter is donationware. If you are using it, please donate.
+ * http://alexgorbatchev.com/SyntaxHighlighter/donate.html
+ *
+ * @version
+ * 3.0.83 (July 02 2010)
+ * 
+ * @copyright
+ * Copyright (C) 2004-2010 Alex Gorbatchev.
+ *
+ * @license
+ * Dual licensed under the MIT and GPL licenses.
+ */
+.syntaxhighlighter {
+  background-color: #121212 !important;
+}
+.syntaxhighlighter .line.alt1 {
+  background-color: #121212 !important;
+}
+.syntaxhighlighter .line.alt2 {
+  background-color: #121212 !important;
+}
+.syntaxhighlighter .line.highlighted.alt1, .syntaxhighlighter .line.highlighted.alt2 {
+  background-color: #2c2c29 !important;
+}
+.syntaxhighlighter .line.highlighted.number {
+  color: white !important;
+}
+.syntaxhighlighter table caption {
+  color: white !important;
+}
+.syntaxhighlighter .gutter {
+  color: #afafaf !important;
+}
+.syntaxhighlighter .gutter .line {
+  border-right: 3px solid #3185b9 !important;
+}
+.syntaxhighlighter .gutter .line.highlighted {
+  background-color: #3185b9 !important;
+  color: #121212 !important;
+}
+.syntaxhighlighter.printing .line .content {
+  border: none !important;
+}
+.syntaxhighlighter.collapsed {
+  overflow: visible !important;
+}
+.syntaxhighlighter.collapsed .toolbar {
+  color: #3185b9 !important;
+  background: black !important;
+  border: 1px solid #3185b9 !important;
+}
+.syntaxhighlighter.collapsed .toolbar a {
+  color: #3185b9 !important;
+}
+.syntaxhighlighter.collapsed .toolbar a:hover {
+  color: #d01d33 !important;
+}
+.syntaxhighlighter .toolbar {
+  color: white !important;
+  background: #3185b9 !important;
+  border: none !important;
+}
+.syntaxhighlighter .toolbar a {
+  color: white !important;
+}
+.syntaxhighlighter .toolbar a:hover {
+  color: #96daff !important;
+}
+.syntaxhighlighter .plain, .syntaxhighlighter .plain a {
+  color: white !important;
+}
+.syntaxhighlighter .comments, .syntaxhighlighter .comments a {
+  color: #696854 !important;
+}
+.syntaxhighlighter .string, .syntaxhighlighter .string a {
+  color: #e3e658 !important;
+}
+.syntaxhighlighter .keyword {
+  color: #d01d33 !important;
+}
+.syntaxhighlighter .preprocessor {
+  color: #435a5f !important;
+}
+.syntaxhighlighter .variable {
+  color: #898989 !important;
+}
+.syntaxhighlighter .value {
+  color: #009900 !important;
+}
+.syntaxhighlighter .functions {
+  color: #aaaaaa !important;
+}
+.syntaxhighlighter .constants {
+  color: #96daff !important;
+}
+.syntaxhighlighter .script {
+  font-weight: bold !important;
+  color: #d01d33 !important;
+  background-color: none !important;
+}
+.syntaxhighlighter .color1, .syntaxhighlighter .color1 a {
+  color: #ffc074 !important;
+}
+.syntaxhighlighter .color2, .syntaxhighlighter .color2 a {
+  color: #4a8cdb !important;
+}
+.syntaxhighlighter .color3, .syntaxhighlighter .color3 a {
+  color: #96daff !important;
+}
+
+.syntaxhighlighter .functions {
+  font-weight: bold !important;
+}

--- a/src/main/webapp/css/shThemeMDUltra.css
+++ b/src/main/webapp/css/shThemeMDUltra.css
@@ -1,0 +1,113 @@
+/**
+ * SyntaxHighlighter
+ * http://alexgorbatchev.com/SyntaxHighlighter
+ *
+ * SyntaxHighlighter is donationware. If you are using it, please donate.
+ * http://alexgorbatchev.com/SyntaxHighlighter/donate.html
+ *
+ * @version
+ * 3.0.83 (July 02 2010)
+ * 
+ * @copyright
+ * Copyright (C) 2004-2010 Alex Gorbatchev.
+ *
+ * @license
+ * Dual licensed under the MIT and GPL licenses.
+ */
+.syntaxhighlighter {
+  background-color: #222222 !important;
+}
+.syntaxhighlighter .line.alt1 {
+  background-color: #222222 !important;
+}
+.syntaxhighlighter .line.alt2 {
+  background-color: #222222 !important;
+}
+.syntaxhighlighter .line.highlighted.alt1, .syntaxhighlighter .line.highlighted.alt2 {
+  background-color: #253e5a !important;
+}
+.syntaxhighlighter .line.highlighted.number {
+  color: white !important;
+}
+.syntaxhighlighter table caption {
+  color: lime !important;
+}
+.syntaxhighlighter .gutter {
+  color: #38566f !important;
+}
+.syntaxhighlighter .gutter .line {
+  border-right: 3px solid #435a5f !important;
+}
+.syntaxhighlighter .gutter .line.highlighted {
+  background-color: #435a5f !important;
+  color: #222222 !important;
+}
+.syntaxhighlighter.printing .line .content {
+  border: none !important;
+}
+.syntaxhighlighter.collapsed {
+  overflow: visible !important;
+}
+.syntaxhighlighter.collapsed .toolbar {
+  color: #428bdd !important;
+  background: black !important;
+  border: 1px solid #435a5f !important;
+}
+.syntaxhighlighter.collapsed .toolbar a {
+  color: #428bdd !important;
+}
+.syntaxhighlighter.collapsed .toolbar a:hover {
+  color: lime !important;
+}
+.syntaxhighlighter .toolbar {
+  color: #aaaaff !important;
+  background: #435a5f !important;
+  border: none !important;
+}
+.syntaxhighlighter .toolbar a {
+  color: #aaaaff !important;
+}
+.syntaxhighlighter .toolbar a:hover {
+  color: #9ccff4 !important;
+}
+.syntaxhighlighter .plain, .syntaxhighlighter .plain a {
+  color: lime !important;
+}
+.syntaxhighlighter .comments, .syntaxhighlighter .comments a {
+  color: #428bdd !important;
+}
+.syntaxhighlighter .string, .syntaxhighlighter .string a {
+  color: lime !important;
+}
+.syntaxhighlighter .keyword {
+  color: #aaaaff !important;
+}
+.syntaxhighlighter .preprocessor {
+  color: #8aa6c1 !important;
+}
+.syntaxhighlighter .variable {
+  color: aqua !important;
+}
+.syntaxhighlighter .value {
+  color: #f7e741 !important;
+}
+.syntaxhighlighter .functions {
+  color: #ff8000 !important;
+}
+.syntaxhighlighter .constants {
+  color: yellow !important;
+}
+.syntaxhighlighter .script {
+  font-weight: bold !important;
+  color: #aaaaff !important;
+  background-color: none !important;
+}
+.syntaxhighlighter .color1, .syntaxhighlighter .color1 a {
+  color: red !important;
+}
+.syntaxhighlighter .color2, .syntaxhighlighter .color2 a {
+  color: yellow !important;
+}
+.syntaxhighlighter .color3, .syntaxhighlighter .color3 a {
+  color: #ffaa3e !important;
+}

--- a/src/main/webapp/css/shThemeRDark.css
+++ b/src/main/webapp/css/shThemeRDark.css
@@ -1,0 +1,113 @@
+/**
+ * SyntaxHighlighter
+ * http://alexgorbatchev.com/SyntaxHighlighter
+ *
+ * SyntaxHighlighter is donationware. If you are using it, please donate.
+ * http://alexgorbatchev.com/SyntaxHighlighter/donate.html
+ *
+ * @version
+ * 3.0.83 (July 02 2010)
+ * 
+ * @copyright
+ * Copyright (C) 2004-2010 Alex Gorbatchev.
+ *
+ * @license
+ * Dual licensed under the MIT and GPL licenses.
+ */
+.syntaxhighlighter {
+  background-color: #1b2426 !important;
+}
+.syntaxhighlighter .line.alt1 {
+  background-color: #1b2426 !important;
+}
+.syntaxhighlighter .line.alt2 {
+  background-color: #1b2426 !important;
+}
+.syntaxhighlighter .line.highlighted.alt1, .syntaxhighlighter .line.highlighted.alt2 {
+  background-color: #323e41 !important;
+}
+.syntaxhighlighter .line.highlighted.number {
+  color: #b9bdb6 !important;
+}
+.syntaxhighlighter table caption {
+  color: #b9bdb6 !important;
+}
+.syntaxhighlighter .gutter {
+  color: #afafaf !important;
+}
+.syntaxhighlighter .gutter .line {
+  border-right: 3px solid #435a5f !important;
+}
+.syntaxhighlighter .gutter .line.highlighted {
+  background-color: #435a5f !important;
+  color: #1b2426 !important;
+}
+.syntaxhighlighter.printing .line .content {
+  border: none !important;
+}
+.syntaxhighlighter.collapsed {
+  overflow: visible !important;
+}
+.syntaxhighlighter.collapsed .toolbar {
+  color: #5ba1cf !important;
+  background: black !important;
+  border: 1px solid #435a5f !important;
+}
+.syntaxhighlighter.collapsed .toolbar a {
+  color: #5ba1cf !important;
+}
+.syntaxhighlighter.collapsed .toolbar a:hover {
+  color: #5ce638 !important;
+}
+.syntaxhighlighter .toolbar {
+  color: white !important;
+  background: #435a5f !important;
+  border: none !important;
+}
+.syntaxhighlighter .toolbar a {
+  color: white !important;
+}
+.syntaxhighlighter .toolbar a:hover {
+  color: #e0e8ff !important;
+}
+.syntaxhighlighter .plain, .syntaxhighlighter .plain a {
+  color: #b9bdb6 !important;
+}
+.syntaxhighlighter .comments, .syntaxhighlighter .comments a {
+  color: #878a85 !important;
+}
+.syntaxhighlighter .string, .syntaxhighlighter .string a {
+  color: #5ce638 !important;
+}
+.syntaxhighlighter .keyword {
+  color: #5ba1cf !important;
+}
+.syntaxhighlighter .preprocessor {
+  color: #435a5f !important;
+}
+.syntaxhighlighter .variable {
+  color: #ffaa3e !important;
+}
+.syntaxhighlighter .value {
+  color: #009900 !important;
+}
+.syntaxhighlighter .functions {
+  color: #ffaa3e !important;
+}
+.syntaxhighlighter .constants {
+  color: #e0e8ff !important;
+}
+.syntaxhighlighter .script {
+  font-weight: bold !important;
+  color: #5ba1cf !important;
+  background-color: none !important;
+}
+.syntaxhighlighter .color1, .syntaxhighlighter .color1 a {
+  color: #e0e8ff !important;
+}
+.syntaxhighlighter .color2, .syntaxhighlighter .color2 a {
+  color: white !important;
+}
+.syntaxhighlighter .color3, .syntaxhighlighter .color3 a {
+  color: #ffaa3e !important;
+}

--- a/src/main/webapp/js/application.js
+++ b/src/main/webapp/js/application.js
@@ -27,7 +27,35 @@ function updateIfRequired(){
         }
         setTimeout('updateIfRequired()', 2000);
     })
-
 }
 
-updateIfRequired();
+function enableTheme(themeName) {
+    var link = $('#theme-link-' + themeName.toLowerCase());
+    $('link[title^=theme-]').prop('disabled', true);
+    $('link[title=theme-' + themeName.toLowerCase() + ']').prop('disabled', false);
+
+    $('#themes a')
+        .prop('disabled', false)
+        .css('color', '')
+        .css('text-decoration', '');
+    link.prop('disabled', true)
+        .css('color', '#ccc')
+        .css('text-decoration', 'none');
+}
+
+$(document).ready(function() {
+    var themes = ['Default', 'Django', 'Eclipse', 'Emacs', 'FadeToGrey', 'MDUltra', 'Midnight', 'RDark'];
+    var themesElement = $('#themes');
+    $.each(themes, function(i, theme) {
+        var link = $('<a href="#">').attr('id', 'theme-link-' + theme.toLowerCase()).text(theme);
+        link.click(function() {
+            enableTheme(theme);
+        });
+        themesElement.append(link).append(' ');
+    });
+});
+
+$(document).ready(function() {
+    updateIfRequired();
+    enableTheme('Midnight');
+});


### PR DESCRIPTION
We used this in an LSCC hands-on session and the code was unreadable. Midnight is not a good theme for a projector. This fix adds links to change theme between all the default SyntaxHighlighter themes.
